### PR TITLE
Hack: Prevent type foredrag to overflow program title

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -8,9 +8,13 @@
   --hover-bg-color: #f5f5f5;
   --theme-switcher-button: #fff;
 
-  --font-sans: -apple-system, BlinkMacSystemFont, Segoe UI, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
-  --font-mono: FMono-Regular, Consolas, DejaVu Sans Mono, Liberation Mono, Menlo, monospace;
-  --font-serif: Iowan Old Style, Apple Garamond, Baskerville, Georgia, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji;
+  --font-sans: -apple-system, BlinkMacSystemFont, Segoe UI, avenir next, avenir,
+    helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+  --font-mono: FMono-Regular, Consolas, DejaVu Sans Mono, Liberation Mono, Menlo,
+    monospace;
+  --font-serif: Iowan Old Style, Apple Garamond, Baskerville, Georgia,
+    Times New Roman, Droid Serif, Times, Source Serif Pro, serif,
+    Apple Color Emoji;
 
   --font-size-desktop: 18px;
   --font-size-mobile: 15px;
@@ -20,14 +24,13 @@
 
   --bp-medium: 600px;
   --bp-large: 768px;
-
 }
 
 [data-theme="dark"] {
-  --background-color: #1C1F20;
+  --background-color: #1c1f20;
   --font-color: white;
   --logo-font-color: black;
-  --primary-color: #00F5C9;
+  --primary-color: #00f5c9;
   --button-text: #171717;
   --odd-bg-color: #323536;
   --hover-bg-color: #141414;
@@ -158,7 +161,6 @@ section.program ul {
   padding: 0;
 
   li {
-
     &:nth-child(even) {
       background-color: var(--odd-bg-color);
     }
@@ -174,7 +176,7 @@ section.program ul {
       display: block;
     }
 
-    &>* {
+    & > * {
       padding: var(--default-padding);
 
       @media screen and (max-width: 640px) {
@@ -185,6 +187,9 @@ section.program ul {
     h3 {
       grid-area: heading;
       margin: 0;
+      max-width: calc(
+        100vw - 155px
+      ); // FIXME: this is a hack to prevent program title to be under the "foredrag" type box
     }
 
     .time {


### PR DESCRIPTION
This is a hack that temporarily solves #10 but we should fix it by other means. @timharek might already be on this experimenting with alternative design

Before:
<img width="392" alt="image" src="https://github.com/fribyte-code/boskonf.no/assets/5204006/c5b053d9-0c44-42ea-bcd1-4d538fbe78ac">


After:
<img width="466" alt="image" src="https://github.com/fribyte-code/boskonf.no/assets/5204006/951089fe-4426-453c-b35c-2107226cc7a0">
