### PR TITLE
chore: update meta description

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const lang = getLangFromUrl(Astro.url);
 <html lang={lang}>
   <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
+    <meta name="description" content="Bergen Open Source er en årlig teknologikonferanse i Bergen drevet av studenter og andre frivillige. Konferansen har fokus på fri åpen kildekode og åpne data." />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
I noticed that Slack's generated preview said "Astro description" and replaced it with the description from the BOS Konf front page.

<img width="248" alt="image" src="https://github.com/user-attachments/assets/c74ce867-5eb7-4083-8502-30928913fea5">

I guess one could opt to localize the meta description, but as the `<title>` seems hard coded to Norwegian, at least they'll always fit together.