### PR TITLE
:speech_balloon: fix location in FAQ & maillink in Contact

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,20 +1,14 @@
 <div class="cont">
   <div class="contactCont">
     <span class="title">CONTACT</span>
-    <span>post@boskonf.no</span>
+    <a href="mailto:post@boskonf.no"><span>post@boskonf.no</span></a>
   </div>
   <div class="socialsCont">
     <span class="title">SOCIAL</span>
     <div class="socialCont">
-      <!-- <a href="/">
-        <img src="/contact/instagram.svg" alt="instagram icon" />
-      </a> -->
       <a href="https://www.linkedin.com/company/boskonf">
         <img src="/contact/linkedin.svg" alt="linkedin icon" />
       </a>
-      <!-- <a href="/">
-        <img src="/contact/facebook.svg" alt="facebook icon" />
-      </a> -->
     </div>
   </div>
 </div>

--- a/src/components/Main/FAQ.astro
+++ b/src/components/Main/FAQ.astro
@@ -15,7 +15,7 @@ const questionsNO: Question[] = [
   {
     question: "Hvor finner konferansen sted?",
     answer:
-      "Konferansen finner sted i Tivoli på det Akademiske Kvarter, Olav Kyrres Gate 49, Bergen.",
+      "Konferansen finner sted i Storelogen på det Akademiske Kvarter, Olav Kyrres Gate 49, Bergen.",
   },
   {
     question: "Blir det bar?",
@@ -25,7 +25,7 @@ const questionsNO: Question[] = [
   {
     question: "Er det gratis?",
     answer:
-      "Ja, konferansen er gratis of åpen for alle på grunn av våre snille sponsorer.",
+      "Ja, konferansen er gratis og åpen for alle på grunn av våre snille sponsorer.",
   },
 ];
 
@@ -43,7 +43,7 @@ const questionsEN: Question[] = [
   {
     question: "Where is the conference located?",
     answer:
-      "The conference is located at Tivoli at the Academic Quarter, Olav Kyrres Gate 49, Bergen.",
+      "The conference is located at Storelogen at the Academic Quarter, Olav Kyrres Gate 49, Bergen.",
   },
   {
     question: "Will there be a bar?",


### PR DESCRIPTION
Location was set to Tivoli instead of Storelogen, and mail in Contact didn't have an href with `mailto:` :sweat_smile: 