### PR TITLE
Add video URLs

### DIFF
--- a/src/program/2024.ts
+++ b/src/program/2024.ts
@@ -43,6 +43,7 @@ const program2024: Program = {
       from: "2024-11-07T17:10:00",
       to: "2024-11-07T17:20:00",
       type: "talk",
+      videoUrl: "https://files.fribyte.no/boskonf/2024/sindre.mp4",
     },
     {
       title: "Hvor er damene?",
@@ -61,6 +62,8 @@ const program2024: Program = {
       from: "2024-11-07T17:30:00",
       to: "2024-11-07T18:00:00",
       type: "talk",
+      videoUrl:
+        "https://files.fribyte.no/boskonf/2024/nav_where_are_the_girls.webm",
     },
     {
       title: "Mat",
@@ -91,6 +94,7 @@ const program2024: Program = {
       from: "2024-11-07T19:00:00",
       to: "2024-11-07T19:20:00",
       type: "talk",
+      videoUrl: "https://files.fribyte.no/boskonf/2024/bluesky.mp4",
     },
     {
       title: "Om Bærekraftig Emballasje til Open Source Moduler",
@@ -109,38 +113,45 @@ const program2024: Program = {
       from: "2024-11-07T19:20:00",
       to: "2024-11-07T19:30:00",
       type: "talk",
+      videoUrl: "https://files.fribyte.no/boskonf/2024/kent_inge.mp4",
     },
     {
       title: "Distribuere programvare på Linux",
       title_en: "Distributing software on Linux",
-      description: "Å distribuere programvare på Linux kan være komplisert. I motsetning til andre operativsystemer er tredjepartsapplikasjoner ikke lett kompatible på tvers av distribusjoner på grunn av avhengigheter. Vi vil utforske vanlige Linux API-er, delte biblioteker og verktøy som Snap, Flatpak og flere for å forstå hvordan man trygt kan distribuere apper på tvers av distribusjoner.",
-      description_en: "Distributing software on Linux can be complex. Unlike other OSes, third-party apps aren't easily compatible across distributions due to dependencies. We'll explore common Linux APIs, shared libraries, and tools like Snap, Flatpak, and more, to understand how to distribute apps safely across distros.",
+      description:
+        "Å distribuere programvare på Linux kan være komplisert. I motsetning til andre operativsystemer er tredjepartsapplikasjoner ikke lett kompatible på tvers av distribusjoner på grunn av avhengigheter. Vi vil utforske vanlige Linux API-er, delte biblioteker og verktøy som Snap, Flatpak og flere for å forstå hvordan man trygt kan distribuere apper på tvers av distribusjoner.",
+      description_en:
+        "Distributing software on Linux can be complex. Unlike other OSes, third-party apps aren't easily compatible across distributions due to dependencies. We'll explore common Linux APIs, shared libraries, and tools like Snap, Flatpak, and more, to understand how to distribute apps safely across distros.",
       speaker: {
         name: "Valentin David",
         description: "Utvikler, Canonical",
         description_en: "Software Engineer, Canonical",
-        imageUrl: "/speakers/Valentin-David.webp"
+        imageUrl: "/speakers/Valentin-David.webp",
       },
       image: "TODO: path to some image in static dir",
       from: "2024-11-07T19:30:00",
       to: "2024-11-07T19:50:00",
       type: "talk",
+      videoUrl: "https://files.fribyte.no/boskonf/2024/valentin_david.mp4",
     },
     {
       title: "Hva skal til for at Open Source vinner AI-racet?",
       title_en: "What will it take for Open Source to win the AI race?",
-      description: "OpenAI holder ChatGPT lukket for å beskytte sin forretningsmodell, mens Meta gjør LLaMa åpen kildekode for å utfordre konkurrentene. Google balanserer mellom åpenhet og kommersielle hensyn. Vi utforsker hva som ligger bak disse strategiske valgene og deres fremtidige påvirkning.",
-      description_en: "OpenAI keeps ChatGPT closed to protect its business, while Meta open-sourced LLaMa to challenge competitors. Google balances openness with commercial interests. This talk explores the strategic reasons behind these decisions and their impact on the future of AI development.",
+      description:
+        "OpenAI holder ChatGPT lukket for å beskytte sin forretningsmodell, mens Meta gjør LLaMa åpen kildekode for å utfordre konkurrentene. Google balanserer mellom åpenhet og kommersielle hensyn. Vi utforsker hva som ligger bak disse strategiske valgene og deres fremtidige påvirkning.",
+      description_en:
+        "OpenAI keeps ChatGPT closed to protect its business, while Meta open-sourced LLaMa to challenge competitors. Google balances openness with commercial interests. This talk explores the strategic reasons behind these decisions and their impact on the future of AI development.",
       speaker: {
         name: "Oskar Nyland",
         description: "Brukeropplevelseskonsulent, Capgemini",
         description_en: "User Experience Consultant, Capgemini",
-        imageUrl: "/speakers/Oskar-Nyland.webp"
+        imageUrl: "/speakers/Oskar-Nyland.webp",
       },
       image: "TODO: path to some image in static dir",
       from: "2024-11-07T19:50:00",
       to: "2024-11-07T20:00:00",
       type: "talk",
+      videoUrl: "https://files.fribyte.no/boskonf/2024/oskar.webm",
     },
     {
       title: "Takke for kvelden",


### PR DESCRIPTION
Videos are uploaded to files.fribyte.no, and we have support for them from last year

I do not have the slides, so that should probably come in another PR

There is one video missing (the 2nd talk). That i will upload once it is exported

![image](https://github.com/user-attachments/assets/a579374f-2e19-414f-9c99-e5eec2ee8d03)
